### PR TITLE
fix: SKU重复时自动添加*1、*2后缀

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -199,7 +199,6 @@
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    alert(data.message);
                     location.reload();
                 } else {
                     alert(data.message);


### PR DESCRIPTION
- 移除数据库唯一约束，允许同一SKU在同一库位多次添加
- 添加generate_unique_sku函数，自动为重复SKU添加后缀
- 第一次重复：SKU*1，第二次重复：SKU*2，以此类推
- 添加成功时提示用户SKU是否被修改