### PR TITLE
feat: Add SKU Order Analytics Panel with Stacked Bar Chart (Issue #29)

### DIFF
--- a/frontend-v2/src/components/SKUOrderAnalytics.tsx
+++ b/frontend-v2/src/components/SKUOrderAnalytics.tsx
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import apiClient from '../apiClient';
+
+interface SKUOrderStat {
+    sku: string;
+    inventory: number;
+    pending: number;
+    completed: number;
+}
+
+const SKUOrderAnalytics = ({ refreshKey = 0 }: { refreshKey?: number }) => {
+    const [stats, setStats] = useState<SKUOrderStat[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchStats = async () => {
+            setLoading(true);
+            try {
+                const response = await apiClient.get<SKUOrderStat[]>('/sku-order-stats');
+                setStats(response.data);
+            } catch (error) {
+                console.error('Failed to fetch SKU order analytics:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchStats();
+    }, [refreshKey]);
+
+    if (loading) return <div className="bg-gray-800 rounded-lg p-6 border border-gray-700"><div className="p-8 text-center text-gray-400">Loading analytics...</div></div>;
+    if (stats.length === 0) return (
+        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+            <h2 className="text-xl font-bold mb-6 text-white border-b-2 border-emerald-500 pb-2 inline-block">
+                Inventory vs Work Orders
+            </h2>
+            <div className="p-8 text-center text-gray-400">No data available yet</div>
+        </div>
+    );
+
+    const maxTotal = Math.max(...stats.map(s => s.inventory + s.pending + s.completed), 1);
+
+    return (
+        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+            <h2 className="text-xl font-bold mb-6 text-white border-b-2 border-emerald-500 pb-2 inline-block">
+                Inventory vs Work Orders (Stacked)
+            </h2>
+
+            {/* Legend */}
+            <div className="flex gap-4 mb-6 text-xs justify-end">
+                <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-blue-500 inline-block"></span>
+                    <span className="text-gray-400">Inventory</span>
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-amber-500 inline-block"></span>
+                    <span className="text-gray-400">Pending</span>
+                </span>
+                <span className="flex items-center gap-1">
+                    <span className="w-3 h-3 rounded bg-emerald-500 inline-block"></span>
+                    <span className="text-gray-400">Completed</span>
+                </span>
+            </div>
+
+            <div className="space-y-6">
+                {stats.map((item) => {
+                    const total = item.inventory + item.pending + item.completed;
+                    return (
+                        <div key={item.sku} className="group">
+                            <div className="flex justify-between items-end mb-1">
+                                <span className="text-xs font-bold text-gray-300 truncate" title={item.sku}>
+                                    {item.sku}
+                                </span>
+                                <span className="text-[10px] text-gray-500 font-mono">
+                                    Total: {total}
+                                </span>
+                            </div>
+                            <div className="flex-grow bg-gray-900/50 h-6 rounded-md overflow-hidden flex border border-gray-700 shadow-inner">
+                                {/* Inventory segment */}
+                                {item.inventory > 0 && (
+                                    <div
+                                        className="bg-blue-500 h-full transition-all duration-500 ease-out border-r border-black/10 flex items-center justify-center"
+                                        style={{ width: `${(item.inventory / maxTotal) * 100}%` }}
+                                        title={`Inventory: ${item.inventory}`}
+                                    >
+                                        {(item.inventory / maxTotal) > 0.05 && (
+                                            <span className="text-[10px] font-bold text-white drop-shadow-sm">{item.inventory}</span>
+                                        )}
+                                    </div>
+                                )}
+                                {/* Pending segment */}
+                                {item.pending > 0 && (
+                                    <div
+                                        className="bg-amber-500 h-full transition-all duration-500 ease-out border-r border-black/10 flex items-center justify-center"
+                                        style={{ width: `${(item.pending / maxTotal) * 100}%` }}
+                                        title={`Pending: ${item.pending}`}
+                                    >
+                                        {(item.pending / maxTotal) > 0.05 && (
+                                            <span className="text-[10px] font-bold text-white drop-shadow-sm">{item.pending}</span>
+                                        )}
+                                    </div>
+                                )}
+                                {/* Completed segment */}
+                                {item.completed > 0 && (
+                                    <div
+                                        className="bg-emerald-500 h-full transition-all duration-500 ease-out flex items-center justify-center"
+                                        style={{ width: `${(item.completed / maxTotal) * 100}%` }}
+                                        title={`Completed: ${item.completed}`}
+                                    >
+                                        {(item.completed / maxTotal) > 0.05 && (
+                                            <span className="text-[10px] font-bold text-white drop-shadow-sm">{item.completed}</span>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export default SKUOrderAnalytics;

--- a/frontend-v2/src/pages/AccessoriesPage.tsx
+++ b/frontend-v2/src/pages/AccessoriesPage.tsx
@@ -4,6 +4,7 @@ import { Trash2, Eye, RefreshCw } from 'lucide-react';
 import apiClient from '../apiClient';
 import Pagination from '../components/Pagination';
 import SKUStatistics from '../components/SKUStatistics';
+import SKUOrderAnalytics from '../components/SKUOrderAnalytics';
 import AddAccessoryForm from '../components/AddAccessoryForm';
 import AccessoryDetailModal from '../components/AccessoryDetailModal';
 
@@ -166,9 +167,7 @@ const AccessoriesPage = () => {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
         <SKUStatistics refreshKey={refreshKey} />
-        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 flex items-center justify-center text-gray-500 italic">
-          More statistics coming soon...
-        </div>
+        <SKUOrderAnalytics refreshKey={refreshKey} />
       </div>
 
       <AccessoryDetailModal


### PR DESCRIPTION
## Summary

Implements a new Inventory vs Work Orders analytics panel on the Accessories page.

## Changes

### Backend
- New endpoint: /api/sku-order-stats
  - Aggregates inventory counts by base SKU (handles SKU*N variants)
  - Returns pending and completed work order counts per SKU

### Frontend
- New component: SKUOrderAnalytics.tsx - stacked horizontal bar chart (pure CSS)
  - Three color segments per SKU: Inventory (blue) / Pending (amber) / Completed (green)
  - Inline value labels when segment width > 5%
- Updated: AccessoriesPage.tsx - integrated in 2-column grid alongside SKU Statistics

## Verification
- npm run build success - 0 TypeScript/Vite errors

Closes #29